### PR TITLE
coffeelint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ More linters will be supported in the future.
 
 * [RuboCop](https://github.com/bbatsov/rubocop) for Ruby
 * [flake8](https://flake8.readthedocs.org/) for Python
-* [JSHint](http://www.jshint.com/docs/) for JavaScript
 * [HLint](http://community.haskell.org/~ndm/hlint/) for Haskell
-  (Installation of [language-haskell](https://atom.io/packages/language-haskell) package is required)
+(Installation of [language-haskell](https://atom.io/packages/language-haskell) package is required)
+* [JSHint](http://www.jshint.com/docs/) for JavaScript
+* [CoffeeLint](http://www.coffeelint.org/) for CoffeeScript
 
 ## Installation
 
@@ -53,35 +54,21 @@ You can configure Atom-Lint by editing `~/.atom/config.cson` (choose **Open Your
 ```cson
 # Some other settings...
 'atom-lint':
-  'rubocop':
-    'path': '/path/to/bin/rubocop'
+  'coffeelint':
+    'path': '/path/to/bin/coffeelint'
   'flake8':
     'path': '/path/to/bin/flake8'
-  'jshint':
-    'path': '/path/to/bin/jshint'
   'hlint':
     'path': '/path/to/bin/hlint'
+  'jshint':
+    'path': '/path/to/bin/jshint'
+  'rubocop':
+    'path': '/path/to/bin/rubocop'
 ```
 
-### `atom-lint.rubocop.path`
-
-Specify an executable path for `rubocop` command.
-
 By default Atom-Lint automatically refers the environement variable `PATH` of your login shell
-if it's `bash` or `zsh`, and invokes `rubocop` command.
+if it's `bash` or `zsh`, and then invokes the command.
 If you got a problem with `PATH`, use this setting.
-
-### `atom-lint.flake8.path`
-
-Specify an executable path for `flake8` command. Similar to the `rubocop` path argument described above.
-
-### `atom-lint.jshint.path`
-
-Specify an executable path for `jshint` command. Similar to the `rubocop` path argument described above.
-
-### `atom-lint.hlint.path`
-
-Specify an executable path for `hlint` command. Similar to the `rubocop` path argument described above.
 
 ## Contributors
 

--- a/lib/linter-map.cson
+++ b/lib/linter-map.cson
@@ -4,3 +4,4 @@
 'source.js': 'jshint'
 'source.haskell': 'hlint'
 'text.tex.latex.haskell': 'hlint'
+'source.coffee': 'coffeelint'

--- a/lib/linter/coffeelint.coffee
+++ b/lib/linter/coffeelint.coffee
@@ -1,0 +1,58 @@
+{Range, Point} = require 'atom'
+CommandRunner = require '../command-runner'
+
+module.exports =
+class CoffeeLint
+  constructor: (@filePath) ->
+
+  run: (callback) ->
+    @runCoffeeLint (error, violations) =>
+      if error?
+        callback(error)
+      else
+        callback(null, violations)
+
+  runCoffeeLint: (callback) ->
+    runner = new CommandRunner(@constructCommand())
+
+    runner.run (error, result) ->
+      return callback(error) if error?
+
+      pattern = ///
+        ^(.+),(\d+),(\d*),(error|warn),(.+)$
+      ///
+
+      if result.exitCode == 0 || result.exitCode == 1
+        violations = []
+        items = result.stdout.split '\n'
+        for item in items[1...]
+          if not item then continue
+
+          [file, line, col, severity, msg] = item.match(pattern)[1..5]
+
+          col = '1' if col == ''
+          severity = 'warning' if severity == 'warn'
+          bufferPoint = new Point parseInt(line) - 1, parseInt(col) - 1
+
+          violations.push
+            severity: severity
+            message: msg
+            bufferRange: new Range bufferPoint, bufferPoint
+
+        callback(null, violations)
+      else
+        callback(new Error "Process exited with code #{result.exitCode}")
+
+  constructCommand: ->
+    command = []
+
+    userCoffeeLintPath = atom.config.get('atom-lint.coffeelint.path')
+
+    if userCoffeeLintPath?
+      command.push(userCoffeeLintPath)
+    else
+      command.push('coffeelint')
+
+    command.push('--csv')
+    command.push(@filePath)
+    command


### PR DESCRIPTION
Issue #6, quick and dirty

I used command line tool instead of embedding coffeelint.js in order to keep things homogeneous. Using vendor js could speed up thing though

Minor changes to README.md (sort linters and clean custom path section)

No spec yet, but I think linter specs should be refactored to focus only a single base class
