### PR TITLE
Moving count outside of icon

### DIFF
--- a/lib/lint-status-view.coffee
+++ b/lib/lint-status-view.coffee
@@ -53,10 +53,10 @@ class LintStatusView extends View
       else
         errorCount = @countViolationsOfSeverity(violations, 'error')
         if errorCount > 0
-          html += "<span class=\"icon icon-alert lint-error\">#{errorCount}</span>"
+          html += "<span class=\"icon icon-alert lint-error\"></span> #{errorCount}"
         warningCount = @countViolationsOfSeverity(violations, 'warning')
         if warningCount > 0
-          html += "<span class=\"icon icon-alert lint-warning\">#{warningCount}</span>"
+          html += "<span class=\"icon icon-alert lint-warning\"></span> #{warningCount}"
 
     @find('.lint-summary').html(html)
 


### PR DESCRIPTION
There's a small visual bug for the icon with the warnings. It is a little too close to the number

Before:
![screen shot 2014-03-22 at 3 35 32 pm](https://f.cloud.github.com/assets/54012/2492109/8d4740f0-b212-11e3-8347-e6bc90b149ee.png)

After:
![screen shot 2014-03-22 at 3 35 05 pm](https://f.cloud.github.com/assets/54012/2492110/95129b4a-b212-11e3-9623-a38f8b05909e.png)

@yujinakayama
