### PR TITLE
Feature/csslint options

### DIFF
--- a/lib/linter/csslint.coffee
+++ b/lib/linter/csslint.coffee
@@ -10,11 +10,18 @@ class CSSLint extends XmlBase
     command = []
 
     userCSSLintPath = atom.config.get('atom-lint.csslint.path')
+    userCSSLintRules = atom.config.get('atom-lint.csslint.rules')
 
     if userCSSLintPath?
       command.push(userCSSLintPath)
     else
       command.push('csslint')
+
+    # add rule flags
+    if userCSSLintRules?
+      for flag, rules of userCSSLintRules
+        if /errors|ignore|warnings/.test(flag) and Array.isArray(rules)
+          command.push("--#{flag.toLowerCase()}=#{rules.join(',')}")
 
     command.push('--format=checkstyle-xml')
     command.push(@filePath)


### PR DESCRIPTION
Can now add an array of CSSLint options to either ignore, errors, or warnings command line flags in config.json, which should resolve issue #54.

``` coffee-script
'atom-lint':
  'csslint':
    'path': '/usr/local/bin/csslint'
    'rules':
      'ignore': ['adjoining-classes']
```
