### PR TITLE
Add Erlang linting via erlc

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Atom-Lint is currently in beta development.
 ## Supported Linters
 
 More linters will be supported in the future.
-
 * [RuboCop](https://github.com/bbatsov/rubocop) for Ruby
 * [flake8](https://flake8.readthedocs.org/) for Python
 * [HLint](http://community.haskell.org/~ndm/hlint/) for Haskell
@@ -27,6 +26,9 @@ More linters will be supported in the future.
 * [Clang](http://clang.llvm.org) for C/C++/Objective-C
 * [rustc](http://www.rust-lang.org/) for Rust
   (Installation of [language-rust](https://atom.io/packages/language-rust) package is required)
+* [erlc](http://www.erlang.org/) for Erlang
+  (Installation of [language-erlang](https://atom.io/packages/language-erlang) package is required)
+
 
 ## Features
 
@@ -84,6 +86,8 @@ You can configure Atom-Lint by editing `~/.atom/config.cson` (choose **Open Your
     ]
   'csslint':
     'path': '/path/to/bin/csslint'
+  'erlc':
+    'path': '/path/to/bin/erlc'
   'flake8':
     'path': '/path/to/bin/flake8'
   'gc':

--- a/lib/linter-map.cson
+++ b/lib/linter-map.cson
@@ -15,3 +15,4 @@
 'source.objc': 'clang'
 'source.objc++': 'clang'
 'source.rust': 'rustc'
+'source.erlang': 'erlc'

--- a/lib/linter/erlc.coffee
+++ b/lib/linter/erlc.coffee
@@ -1,0 +1,90 @@
+{Range, Point} = require 'atom'
+CommandRunner = require '../command-runner'
+Violation = require '../violation'
+path = require 'path'
+
+DIAGNOSTIC_PATTERN = ///
+^(.+):(\d+):  # file / line
+\s*([^]+) # message
+///
+
+module.exports =
+class Erlc
+  @canonicalName = 'erlc'
+
+  constructor: (@filePath) ->
+
+  run: (callback) ->
+    @runErlc (error, violations) ->
+      if error?
+        callback(error)
+      else
+        callback(null, violations)
+
+  runErlc: (callback) ->
+    runner = new CommandRunner(@buildCommand())
+
+    runner.run (error, result) =>
+      return callback(error) if error?
+
+      if result.exitCode == 0 || result.exitCode == 1
+        violations = @parseDiagnostics(result.stdout)
+        callback(null, violations)
+      else
+        callback(new Error("Process exited with code #{result.exitCode}"))
+
+  parseDiagnostics: (log) ->
+    # Example of erlc output
+    # $ erlc <options> hello.erl
+    # hello.erl:3: function goofy/1 undefined          # an error
+    # hello.erl:12: Warning: function boo/0 is unused  # a warning
+
+    lines = log.split('\n')
+
+    for line in lines
+      continue unless line
+
+      matches = line.match(DIAGNOSTIC_PATTERN)
+      continue unless matches
+      [_, filePath, lineNumber, message] = matches
+
+      severity = "error"
+
+      if message.startsWith("Warning: ")
+        severity = "warning"
+
+      bufferPoint = new Point(parseInt(lineNumber) - 1, 0)
+      bufferRange = new Range(bufferPoint, bufferPoint)
+      new Violation(severity, bufferRange, message)
+
+  buildCommand: ->
+    # The official linter for Erlang is flymake within Emacs
+    # Our build command works in the same way as erlang-flymake.el
+    # see: https://github.com/erlang/otp/blob/maint/lib/tools/emacs/erlang-flymake.el
+    command = []
+    userErlcPath = atom.config.get('atom-lint.erlc.path')
+
+    fileFullPath = @filePath
+    filePathPart = path.dirname(fileFullPath)
+
+    if userErlcPath?
+      command.push(userErlcPath)
+    else
+      command.push('erlc')
+
+    if filePathPart.endsWith("/src")
+      parentPathPart = filePathPart.replace('/src', '/')
+      command.push('-I', "#{ parentPathPart }include/")
+      command.push('-I', "#{ parentPathPart }deps/")
+      command.push('-pa', "#{ parentPathPart }ebin/")
+
+    command.push('-Wall')
+    command.push('+warn_obsolete_guard')
+    command.push('+warn_unused_import')
+    command.push('+warn_shadow_vars')
+    command.push('+warn_export_vars')
+    command.push('+strong_validation')
+    command.push('+report')
+    command.push(fileFullPath)
+    # console.log(command.join(' ')) # Show the command
+    command


### PR DESCRIPTION
Added linting for Erlang. The call to 'erlc' (and the arguments passed) match the logic used by in Erlang's official linting in Emacs provided by flymake.
