### PR TITLE
Add support for Rails Cop

### DIFF
--- a/lib/command-runner.coffee
+++ b/lib/command-runner.coffee
@@ -90,7 +90,11 @@ class CommandRunner
       @runWithEnv(env, callback)
 
   runWithEnv: (env, callback) ->
-    proc = child_process.spawn(@command[0], @command.slice(1), { env: env })
+    options =
+      env: env
+      cwd: atom.project.path
+
+    proc = child_process.spawn(@command[0], @command.slice(1), options)
 
     result =
       command: @command


### PR DESCRIPTION
`rubocop` needs to be ran from the project directory where the Rails app lives to work.  Therefore, if `rubocop` is used then change the CWD to the project path if the Rails flag has been set.

To enable this add `rails: true` to your `config.cson` e.g.

```
'atom-lint':
  'ignoredNames': [
    'tmp/**'
  ]
  'rubocop':
    'rails': true
    'ignoredNames': [
      'db/**'
      'spec/**'
    ]

```

All specs pass in Atom (0.118.0 using React Editor). Using the `rake` command one fails, but it also fails in master, hopefully a separate issue.

```
CommandRunner
  run
    when environment variables of the login shell cannot be fetched
      it runs the command with the current env
```
