### PR TITLE
Fix a bug that couldn't find HOME environment using rubocop

### DIFF
--- a/lib/command-runner.coffee
+++ b/lib/command-runner.coffee
@@ -69,6 +69,7 @@ class CommandRunner
       @fetchEnvOfLoginShell (error, env) =>
         env ?= {}
         @_cachedEnv = @mergePathEnvs(env, process.env)
+        @_cachedEnv['HOME'] = process.env.HOME
         callback(@_cachedEnv)
     else
       callback(@_cachedEnv)


### PR DESCRIPTION
I saw LinterError using rubocop on atom console.

```
LinterError: Failed parsing RuboCop's JSON output ""
    command: ["rubocop","--format","json","/Users/trsw/github/git-trend/lib/git_trend/cli.rb"]
    PATH: /Users/trsw/.composer/vendor/bin:/usr/local/sbin:/usr/local/bin:/Users/trsw/.rbenv/shims:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/opt/go/libexec/bin:/Users/trsw/.go/bin
    exit code: 1
    stdout:

    stderr:
        couldn't find HOME environment -- expanding `~'
        /Users/trsw/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rubocop-0.24.1/lib/rubocop/config_loader.rb:138:in `home'
        /Users/trsw/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rubocop-0.24.1/lib/rubocop/config_loader.rb:138:in `dirs_to_search'
        /Users/trsw/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rubocop-0.24.1/lib/rubocop/config_loader.rb:126:in `config_files_in_path'
        /Users/trsw/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rubocop-0.24.1/lib/rubocop/config_loader.rb:89:in `configuration_file_for'
        /Users/trsw/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rubocop-0.24.1/lib/rubocop/config_store.rb:36:in `for'
        /Users/trsw/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rubocop-0.24.1/lib/rubocop/runner.rb:85:in `inspect_file'
        /Users/trsw/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rubocop-0.24.1/lib/rubocop/runner.rb:69:in `block in process_file'
        /Users/trsw/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rubocop-0.24.1/lib/rubocop/runner.rb:64:in `loop'
        /Users/trsw/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rubocop-0.24.1/lib/rubocop/runner.rb:64:in `process_file'
        /Users/trsw/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rubocop-0.24.1/lib/rubocop/runner.rb:27:in `block in run'
        /Users/trsw/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rubocop-0.24.1/lib/rubocop/runner.rb:25:in `each'
        /Users/trsw/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rubocop-0.24.1/lib/rubocop/runner.rb:25:in `run'
        /Users/trsw/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rubocop-0.24.1/lib/rubocop/cli.rb:24:in `run'
        /Users/trsw/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rubocop-0.24.1/bin/rubocop:14:in `block in <top (required)>'
        /Users/trsw/.rbenv/versions/2.1.2/lib/ruby/2.1.0/benchmark.rb:294:in `realtime'
        /Users/trsw/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rubocop-0.24.1/bin/rubocop:13:in `<top (required)>'
        /Users/trsw/.rbenv/versions/2.1.2/bin/rubocop:23:in `load'
        /Users/trsw/.rbenv/versions/2.1.2/bin/rubocop:23:in `<main>'
```

It is due to using `Dir.home` in rubocop(lib/rubocop/config_loader.rb:138).
It works like this.
