### PR TITLE
Add atom-lint.rubocop.showDisplayCopNames #47

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ You can configure Atom-Lint by editing `~/.atom/config.cson` (choose **Open Your
     'path': '/path/to/bin/puppet-lint'
   'rubocop':
     'path': '/path/to/bin/rubocop'
+    'showDisplayCopNames': false
   'rustc':
     'path': '/path/to/bin/rustc'
   'scss-lint':

--- a/lib/linter/rubocop.coffee
+++ b/lib/linter/rubocop.coffee
@@ -55,11 +55,15 @@ class Rubocop
     command = []
 
     userRubocopPath = atom.config.get('atom-lint.rubocop.path')
+    showDisplayCopNames = atom.config.get('atom-lint.rubocop.showDisplayCopNames')
+    showDisplayCopNames ?= true
 
     if userRubocopPath?
       command.push(userRubocopPath)
     else
       command.push('rubocop')
 
-    command.push('--format', 'json', @filePath)
+    command.push('--format', 'json')
+    command.push '--display-cop-names' if showDisplayCopNames
+    command.push @filePath
     command

--- a/spec/linter/rubocop-spec.coffee
+++ b/spec/linter/rubocop-spec.coffee
@@ -2,25 +2,53 @@ Rubocop = require '../../lib/linter/rubocop'
 
 describe 'Rubocop', ->
   rubocop = null
+  defaultOptions = ['rubocop', '--format', 'json', '--display-cop-names', '/path/to/target.rb']
 
   beforeEach ->
     rubocop = new Rubocop('/path/to/target.rb')
 
   describe 'buildCommand', ->
-    originalRubocopPath = atom.config.get('atom-lint.rubocop.path')
-
-    afterEach ->
-      atom.config.set('atom-lint.rubocop.path', originalRubocopPath)
-
     describe 'when the target file path is "/path/to/target.rb"', ->
-      describe 'and config "atom-lint.rubocop.path" is "/path/to/rubocop"', ->
-        it 'returns ["/path/to/rubocop", "--format", "json", "/path/to/target.rb"]', ->
-          atom.config.set('atom-lint.rubocop.path', '/path/to/rubocop')
-          expect(rubocop.buildCommand())
-            .toEqual(['/path/to/rubocop', '--format', 'json', '/path/to/target.rb'])
+      describe 'path', ->
+        originalRubocopPath = atom.config.get('atom-lint.rubocop.path')
 
-      describe 'and config "atom-lint.rubocop.path" is not set', ->
-        it 'returns ["rubocop", "--format", "json", "/path/to/target.rb"]', ->
-          atom.config.set('atom-lint.rubocop.path', null)
-          expect(rubocop.buildCommand())
-            .toEqual(['rubocop', '--format', 'json', '/path/to/target.rb'])
+        afterEach ->
+          atom.config.set('atom-lint.rubocop.path', originalRubocopPath)
+
+        describe 'and config "atom-lint.rubocop.path" is "/path/to/rubocop"', ->
+          it 'returns ["/path/to/rubocop", "--format", "json", "--display-cop-names",
+          "/path/to/target.rb"]', ->
+            atom.config.set('atom-lint.rubocop.path', '/path/to/rubocop')
+            expect(rubocop.buildCommand())
+              .toEqual(['/path/to/rubocop', '--format', 'json', '--display-cop-names',
+              '/path/to/target.rb'])
+
+        describe 'and config "atom-lint.rubocop.path" is not set', ->
+          it 'returns ["rubocop", "--format", "json", "--display-cop-names",
+          "/path/to/target.rb"]', ->
+            atom.config.set('atom-lint.rubocop.path', null)
+            expect(rubocop.buildCommand()).toEqual(defaultOptions)
+
+      describe 'showDisplayCopNames', ->
+        originaShowDisplayCopNames = atom.config.get('atom-lint.rubocop.showDisplayCopNames')
+
+        afterEach ->
+          atom.config.set('atom-lint.rubocop.path', originaShowDisplayCopNames)
+
+        describe 'and config "atom-lint.rubocop.showDisplayCopNames" is true', ->
+          it 'returns ["rubocop", "--format", "json", "--display-cop-names",
+          "/path/to/target.rb"]', ->
+            atom.config.set('atom-lint.rubocop.showDisplayCopNames', true)
+            expect(rubocop.buildCommand()).toEqual(defaultOptions)
+
+        describe 'and config "atom-lint.rubocop.showDisplayCopNames" is false', ->
+          it 'returns ["rubocop", "--format", "json", "/path/to/target.rb"]', ->
+            atom.config.set('atom-lint.rubocop.showDisplayCopNames', false)
+            expect(rubocop.buildCommand())
+              .toEqual(['rubocop', '--format', 'json', '/path/to/target.rb'])
+
+        describe 'and config "atom-lint.rubocop.showDisplayCopNames" is not set', ->
+          it 'returns ["rubocop", "--format", "json", "--display-cop-names",
+          "/path/to/target.rb"]', ->
+            atom.config.set('atom-lint.rubocop.showDisplayCopNames', null)
+            expect(rubocop.buildCommand()).toEqual(defaultOptions)


### PR DESCRIPTION
I want to use rubocop with `--display-cop-names` option.
How about this?
