### PR TITLE
basic windows support

### DIFF
--- a/lib/command-runner.coffee
+++ b/lib/command-runner.coffee
@@ -14,7 +14,10 @@ module.exports =
 class CommandRunner
   @fetchEnvOfLoginShell: (callback) ->
     if !process.env.SHELL
-      return callback(new Error("SHELL environment variable is not set."))
+      if process.platform == 'win32'
+        return callback(null, null)
+      else
+        return callback(new Error("SHELL environment variable is not set."))
 
     if process.env.SHELL.match(/csh$/)
       # csh/tcsh does not allow to execute a command (-c) in a login shell (-l).
@@ -90,7 +93,13 @@ class CommandRunner
       @runWithEnv(env, callback)
 
   runWithEnv: (env, callback) ->
-    proc = child_process.spawn(@command[0], @command.slice(1), { env: env })
+    if process.platform == 'win32'
+      proc = child_process.spawn('cmd', ['/s', '/c', '"' + @command.join(' ') + '"'], {
+        windowsVerbatimArguments: true,
+        env: env
+      })
+    else
+      proc = child_process.spawn(@command[0], @command.slice(1), { env: env })
 
     result =
       command: @command


### PR DESCRIPTION
Hi, 

I added basic windows support (tested on coffeescript).
Everything is in `process.platform == "win32"` so it shouldn't break other platforms.
