### PR TITLE
Fix crash when line numbers and indent guide are hidden

### DIFF
--- a/lib/lint-view.coffee
+++ b/lib/lint-view.coffee
@@ -80,6 +80,7 @@ class LintView extends View
       violationView.isValid
 
   updateGutterMarkers: ->
+    return if @gutterView.length == 0
     return unless @gutterView.isVisible()
 
     for severity in Violation.SEVERITIES


### PR DESCRIPTION
Hi,

Atom is giving a lot of undefined style errors when both "line numbers" and "indent guide" is disabled in settings. I added a guard to catch this case.
