### PR TITLE
Add Cython linting via flake8

### DIFF
--- a/lib/linter-map.cson
+++ b/lib/linter-map.cson
@@ -2,6 +2,7 @@
 'source.ruby.rails': 'rubocop'
 'source.ruby.rspec': 'rubocop'
 'source.python': 'flake8'
+'source.cython': 'flake8'
 'source.js': 'jshint'
 'source.haskell': 'hlint'
 'text.tex.latex.haskell': 'hlint'


### PR DESCRIPTION
Add support for Cython language via flake8.
Pure python mode of Cython is the same grammar as python.
