### PR TITLE
fixed small error checking missing in createViolationsFromXml: (xml).

### DIFF
--- a/lib/linter/xml-base.coffee
+++ b/lib/linter/xml-base.coffee
@@ -25,7 +25,7 @@ class XmlBase
     throw new Error('::isValidExitCode must be overridden')
 
   createViolationsFromXml: (xml) ->
-    return [] unless xml.checkstyle.file?
+    return [] unless xml? and xml.checkstyle.file?
     for element in xml.checkstyle.file[0].error
       @createViolationFromElement(element)
 


### PR DESCRIPTION
My dev console was filled of "cannot check property xml.checkstyle of null" every time I was saving or opening a file.
This small fix should solve the issue.
