### PR TITLE
remove Yosemite workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,6 @@ once quit and re-launch it from your shell with the `atom` command.
 This is required only once and important to handle the `PATH` environment variable properly.
 See [Linter Executable Paths](#linter-executable-paths) for more details.
 
-### Workaround on OS X Yosemite
-
-On OS X Yosemite, the `PATH` environment variable in Atom is _not_ properly inherited from your login shell
-even if it's launched from the shell.
-To handle this issue, you need to run the following script in your shell once:
-
-```bash
-$ echo "process.env.PATH = '$PATH'" >> ~/.atom/init.coffee
-```
-
 ## Usage
 
 Your source will be linted on open and on save automatically.


### PR DESCRIPTION
The fix has already been merged https://github.com/atom/atom/pull/4064.

Also I believe this workaround shouldn't be an 'official' workaround because if your path changes it will overwrite the correct path. (path can change when updating ruby or other components) 
