### PR TITLE
Handle new scope names for C++, Objective-C++

### DIFF
--- a/lib/linter-map.cson
+++ b/lib/linter-map.cson
@@ -12,8 +12,12 @@
 'source.puppet': 'puppet-lint'
 'source.shell': 'shellcheck'
 'source.c': 'clang'
-'source.c++': 'clang'
+'source.cpp': 'clang'
 'source.objc': 'clang'
-'source.objc++': 'clang'
+'source.objcpp': 'clang'
 'source.rust': 'rustc'
 'source.erlang': 'erlc'
+
+# For backwards compatibility with Atom versions < 0.166
+'source.c++': 'clang'
+'source.objc++': 'clang'


### PR DESCRIPTION
In the next release of Atom (v0.166), the scope name for C++ and Objective-C++ will change from `source.c++` and `source.objc++` to `source.cpp` and `source.objcpp`. This is being done to work around some issues with CSS classes containing '+' characters. This PR adds handling for the new scope names, but will continue to handle the old ones, for compatibility with old versions of Atom.

Refs atom/language-c#54.
