### PR TITLE
Add lint config files to coffeelint and scss-lint

### DIFF
--- a/lib/linter/coffeelint.coffee
+++ b/lib/linter/coffeelint.coffee
@@ -10,11 +10,15 @@ class CoffeeLint extends XmlBase
     command = []
 
     userCoffeeLintPath = atom.config.get('atom-lint.coffeelint.path')
+    userCoffeeLintConfig = atom.config.get('atom-lint.coffeelint.config')
 
     if userCoffeeLintPath?
       command.push(userCoffeeLintPath)
     else
       command.push('coffeelint')
+
+    if userCoffeeLintConfig?
+      command.push('--file', userCoffeeLintConfig)
 
     command.push('--reporter')
     command.push('checkstyle')

--- a/lib/linter/rubocop.coffee
+++ b/lib/linter/rubocop.coffee
@@ -59,11 +59,15 @@ class Rubocop
     command = []
 
     userRubocopPath = atom.config.get('atom-lint.rubocop.path')
+    userRubocopConfig = atom.config.get('atom-lint.rubocop.config')
 
     if userRubocopPath?
       command.push(userRubocopPath)
     else
       command.push('rubocop')
+
+    if userRubocopConfig?
+      command.push('--config', userRubocopConfig)
 
     command.push('--format', 'json', @filePath)
     command

--- a/lib/linter/scss-lint.coffee
+++ b/lib/linter/scss-lint.coffee
@@ -14,11 +14,15 @@ class SCSSLint extends XmlBase
     command = []
 
     userSCSSLintPath = atom.config.get('atom-lint.scss-lint.path')
+    userSCSSLintConfig = atom.config.get('atom-lint.scss-lint.config')
 
     if userSCSSLintPath?
       command.push(userSCSSLintPath)
     else
       command.push('scss-lint')
+
+    if userSCSSLintConfig?
+      command.push('--config', userSCSSLintConfig)
 
     command.push('--format', 'XML')
     command.push(@filePath)


### PR DESCRIPTION
Because coffeelint[1] and scss-lint[2] allow configuration files to be specified from the command line, I've updated atom-lint to allow this to be specified in the `config.cson` file.

The scss-lint key is `atom-lint.scss-lint.config`.  Similarly, the coffeelint key is `atom-lint.coffeelint.config`.

We could probably do this for other languages, too, but coffeelint and scss-lint are the only ones I was actively using and able to test at the time.

[1] http://www.coffeelint.org/#usage (By way of the `--file` or `-f` flag)
[2] https://github.com/causes/scss-lint#usage (By way of the `--config` or `-c` flag)
